### PR TITLE
Fix sortpom consistency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,12 +82,13 @@
           <configuration>
             <createBackupFile>false</createBackupFile>
             <expandEmptyElements>false</expandEmptyElements>
-            <lineSeparator>\n</lineSeparator>
             <keepBlankLines>false</keepBlankLines>
+            <lineSeparator>\n</lineSeparator>
             <nrOfIndentSpace>2</nrOfIndentSpace>
             <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
             <sortDependencies>scope,groupId,artifactId</sortDependencies>
             <sortProperties>true</sortProperties>
+            <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
             <verifyFail>Stop</verifyFail>
           </configuration>
         </plugin>


### PR DESCRIPTION
Ensure consistency of space before an empty element is closed. This
fixes conflicts between different tools, some of which add the space
(like maven-release-plugin) and the sortpom plugin, which previously
removed it, by making the sortpom plugin always add it.

This ensures the `<mailingList />` doesn't keep changing to
`<mailingList/>` back and forth.