### PR TITLE
Bump to 3.0.0 for JDK 11

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse JSDT core
 Bundle-SymbolicName: jsdt-core
 Bundle-Vendor: Revelc
-Bundle-Version: 2.8.2.qualifier
+Bundle-Version: 3.0.0.qualifier
 Require-Bundle: org.eclipse.wst.jsdt.core;bundle-version="[1.0.0,10.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/build.properties
+++ b/build.properties
@@ -2,4 +2,4 @@ source.. = src/
 output.. = target/classes
 bin.includes = META-INF/,\
                .
-jre.compilation.profile = JavaSE-1.8
+jre.compilation.profile = JavaSE-11

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.revelc.code.formatter</groupId>
   <artifactId>jsdt-core</artifactId>
-  <version>2.8.2-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <name>Eclipse JSDT Core Bundle</name>
   <description>Repackaging of Eclipse JSDT bundled for Maven Central</description>


### PR DESCRIPTION
Bump the next version for this library to 3.0.0 for JDK 11, so it is not
confused with a bugfix for 2.8.1, which is the last version built
targeting JDK 8.