### PR TITLE
[metadata] Add automatic module name

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -6,3 +6,4 @@ Bundle-Vendor: Revelc
 Bundle-Version: 3.3.1.qualifier
 Require-Bundle: org.eclipse.wst.jsdt.core;bundle-version="[1.0.0,10.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
+Automatic-Module-Name: org.eclipse.wst.jsdt.core


### PR DESCRIPTION
follows the format used by all other eclipse modules.