### PR TITLE
[maven] Make sure we release sha-512 & sha-256 and use secure checksums

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Daether.checksums.algorithms=SHA-512,SHA-256,SHA-1,MD5
+-Daether.connector.smartChecksums=false


### PR DESCRIPTION
Maven wrapper is required to properly run same maven version on github.  Currently mac is on 3.9.6 but linux/windows are still on 3.8.x.  With maven 3.9 changes, its more important now than ever to be on consistent version.  This was further preventing tycho upgrade.