### PR TITLE
Bump to tycho 4.0.5

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -31,7 +31,7 @@ jobs:
         key: ${{ matrix.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ matrix.os }}-m2
     - name: Download Maven Wrapper
-      run: mvn wrapper:wrapper -Dmaven=3.9.6
+      run: mvn wrapper:wrapper "-Dmaven=3.9.6"
     - name: Build with Maven
       run: ./mvnw -B -V -e "-Dstyle.color=always" verify -DskipFormat -DverifyFormat
       env:

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -30,8 +30,10 @@ jobs:
         path: ~/.m2
         key: ${{ matrix.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ matrix.os }}-m2
+    - name: Download Maven Wrapper
+      run: mvn wrapper:wrapper -Dmaven=3.9.6
     - name: Build with Maven
-      run: mvn -B -V -e "-Dstyle.color=always" verify -DskipFormat -DverifyFormat
+      run: ./mvnw -B -V -e "-Dstyle.color=always" verify -DskipFormat -DverifyFormat
       env:
         MAVEN_OPTS: -Djansi.force=true
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <groupId>net.revelc.code</groupId>
     <artifactId>revelc</artifactId>
     <version>5</version>
+    <relativePath />
   </parent>
   <groupId>net.revelc.code.formatter</groupId>
   <artifactId>jsdt-core</artifactId>
@@ -54,7 +55,7 @@ SPDX-License-Identifier: EPL-2.0
     <mdep.analyze.skip>true</mdep.analyze.skip>
     <!-- rat plugin is no good at validating EPL headers out of the box -->
     <rat.skip>true</rat.skip>
-    <tychoVersion>3.0.5</tychoVersion>
+    <tychoVersion>4.0.5</tychoVersion>
   </properties>
   <repositories>
     <repository>
@@ -155,8 +156,6 @@ SPDX-License-Identifier: EPL-2.0
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <resolver>p2</resolver>
-          <ignoreTychoRepositories>true</ignoreTychoRepositories>
           <pomDependencies>consider</pomDependencies>
           <environments>
             <environment>


### PR DESCRIPTION
Add the Maven Wrapper to the GitHub Actions build to enforce the minimum version of Maven for the tycho plugin, which requires at least 3.9.0