### PR TITLE
[GHA] Rework github actions

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -3,33 +3,24 @@
 
 name: mvn verify
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        java: [17]
+        java: [17, 21]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java }}
-        distribution: zulu
-    - name: Cache local maven repository
-      uses: actions/cache@v4
-      with:
-        path: ~/.m2
-        key: ${{ matrix.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ matrix.os }}-m2
+        distribution: temurin
+        cache: 'maven'
     - name: Download Maven Wrapper
       run: mvn wrapper:wrapper "-Dmaven=3.9.6"
     - name: Build with Maven


### PR DESCRIPTION
- Allow any branch to build as it is not on us to enforce downstream repo usage.  Has zero effect on this repo.
- Make sure we test latest LTS release of java
- Use githubs built in caching for maven