### PR TITLE
[pom] Exclude unnecessary artifacts from the jsdt-bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,7 @@ SPDX-License-Identifier: EPL-2.0
             <configuration>
               <outputDirectory>${project.build.outputDirectory}</outputDirectory>
               <excludes>META-INF/*</excludes>
+              <includeArtifactIds>org.eclipse.core.runtime,org.eclipse.equinox.common,org.eclipse.equinox.registry,org.eclipse.wst.jsdt.core,org.eclipse.wst.common.core,org.eclipse.wst.common.environment,org.eclipse.wst.common.frameworks,org.eclipse.wst.common.project.facet.core,org.eclipse.wst.validation</includeArtifactIds>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
This puts it more on par wit the jdt in overall size.  All tests work with this.

This takes the jar from 35mb to 5mb.  Logic still works, so its a great improvement to not waste downloading large artifact for items not used within it (some that overlaps with the libraries used by formatter).