### PR TITLE
Move to eclipse 2024-12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <url>https://github.com/revelc/jsdt-core</url>
   </scm>
   <properties>
-    <eclipse-repo.url>https://download.eclipse.org/releases/2024-06</eclipse-repo.url>
+    <eclipse-repo.url>https://download.eclipse.org/releases/2024-12</eclipse-repo.url>
     <licenseText><![CDATA[
 This program and the accompanying materials are made
 available under the terms of the Eclipse Public License 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,6 @@
     <url>https://github.com/revelc/jsdt-core</url>
   </scm>
   <properties>
-    <eclipse-repo.url>https://download.eclipse.org/releases/2024-12</eclipse-repo.url>
     <licenseText><![CDATA[
 This program and the accompanying materials are made
 available under the terms of the Eclipse Public License 2.0
@@ -66,7 +65,7 @@ SPDX-License-Identifier: EPL-2.0
   <repositories>
     <repository>
       <id>eclipse</id>
-      <url>${eclipse-repo.url}</url>
+      <url>https://download.eclipse.org/releases/2024-12</url>
       <layout>p2</layout>
     </repository>
   </repositories>


### PR DESCRIPTION
maven 4 further requires the url to be moved as it will not resolve otherwise.  There is no usage outside the url line.

note: tycho doesn't actually work for maven 4 yet so while above is true, using maven 4 fully is not.